### PR TITLE
Fix composer autoload from classmap to files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,6 @@
         "php": ">=5.3.0"
     },
     "autoload": {
-        "classmap": ["src/docopt.php"]
+        "files": ["src/docopt.php"]
     }
 }


### PR DESCRIPTION
Use "files" autoloading instead of "classmap". This will make
composer auto-require the file, and allow it to be actually used
properly.
