### PR TITLE
Updated version on install section.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,7 +97,7 @@ Create a ``composer.json`` file for your project
 
     {
         "require": {
-            "docopt/docopt": "0.5.0"
+            "docopt/docopt": "0.6.0"
         }
     }
 


### PR DESCRIPTION
The stable version of docopt is 0.6.0 (it's the last tag where all tests passed)
