### PR TITLE
Allow 0 as default value.

### DIFF
--- a/src/docopt.php
+++ b/src/docopt.php
@@ -501,7 +501,7 @@ class Option extends ChildPattern
         $this->value = $value;
         
         // Python checks "value is False". maybe we should check "$value === false"
-        if (!$value && $argcount)
+        if (!$value && $value !== '0' && $argcount)
             $this->value = null;
     }
     


### PR DESCRIPTION
If the default value defined in an option is 0, the parser transform the value to null.

As the default value in the parse function signature is $value = false, when we do the validation !$value , internally PHP resolves '0' as false and this is not correct, 0 can be a valid default value.
