### PR TITLE
Fix autoloading via composers autoloader.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,6 @@
         "php": ">=5.3.0"
     },
     "autoload": {
-        "classmap": ["src/docopt.php"]
+        "files": ["src/docopt.php"]
     }
 }


### PR DESCRIPTION
Unfortunately _classmap_ won't work with this library as it only autoloads/maps classes. There are many functions sitting in the Docopt namespace that can't be autoloaded.

Using _files_ fixes this by including src/docopt.php up front.
