### PR TITLE
Use https:// for submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "py"]
 	path = py
-	url = http://github.com/docopt/docopt.git
+	url = https://github.com/docopt/docopt.git


### PR DESCRIPTION
The http:// URL hangs when initializing the submodule via `git submodule
update --init`.
