### PR TITLE
Fix options first behavior

### DIFF
--- a/src/docopt.php
+++ b/src/docopt.php
@@ -937,7 +937,7 @@ function parse_argv($tokens, \ArrayIterator $options, $optionsFirst=false)
             $parsed = array_merge($parsed, parse_shorts($tokens, $options));
         }
         elseif ($optionsFirst) {
-            return array_merge($parsed, array_map(function($v) { return new Argument(null, $v); }, $tokens));
+            return array_merge($parsed, array_map(function($v) { return new Argument(null, $v); }, $tokens->getArrayCopy()));
         }
         else {
             $parsed[] = new Argument(null, $tokens->move());


### PR DESCRIPTION
When `Handler::$optionsFirst` is set to `true` I get the following error stack:

```
array_merge(): Argument #2 is not an array in src/docopt.php on line 85
PHP Warning:  array_merge(): Argument #2 is not an array in src/docopt.php on line 85
Warning:  Invalid argument supplied for foreach() in src/docopt.php on line 997
PHP Warning:  Invalid argument supplied for foreach() in src/docopt.php on line 433
```

It seems that `array_map` was receiving a `TokenStream` object instead of array :)
