### PR TITLE
Remove version from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
     "name": "docopt/docopt",
     "type": "library",
     "description": "Port of Python's docopt for PHP >=5.3",
-    "version": "1.0.3",
     "keywords": ["cli","docs"],
     "homepage": "http://github.com/docopt/docopt.php",
     "license": "MIT",


### PR DESCRIPTION
Composer will look at the tags in the repository to know the versions. Having `version` in `composer.json` will create confusion because ALL commits having the version string that are not tagged do look like that version, too.

See https://getcomposer.org/doc/04-schema.md#version for documentation details.