### PR TITLE
Remove test execution for HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ before_install:
   - composer install
 
 php:
-  - "hhvm"
   - "nightly"
   - "7.1"
   - "7.0"


### PR DESCRIPTION
TravisCI requires using Ubuntu 14 for HHVM, but this prevents testing PHP 5.3 and 5.4 (5.5.9 being the oldest supported version).

Setting up a multi-OS-testing probably can be done, but is too much hassle for the low market share I think.