### PR TITLE
Remove HHVM from required packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0",
-        "hhvm": ">=3.3.0"
+        "php": ">=5.3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.1.*"


### PR DESCRIPTION
With HHVM as a requirement the the library couldn't be installed using `composer require` if HHVM isn't installed as well:

```
> composer require docopt/docopt:1.0.3
Problem 1
  - Installation request for docopt/docopt 1.0.3 -> satisfiable by docopt/docopt[1.0.3].
  - docopt/docopt 1.0.3 requires hhvm >=3.3.0 -> you are running this with PHP and not HHVM.
```

And if you run just `composer require` version 1.0.2 would be installed (since it hasn't HHVM in as a requirement).


Related issues: #13, #11.