### PR TITLE
Fix example in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -251,9 +251,9 @@ the return dictionary will be:
     array(
       '--drifting'=>false,         'mine'=>false,
       '--help'=>false,             'move'=>true,
-      '--moored'=>false,           'new'=>true,
-      '--speed'=>'15',             'remove'=>true,
-      '--version'=>false,          'set'=>true,
+      '--moored'=>false,           'new'=>false,
+      '--speed'=>'15',             'remove'=>false,
+      '--version'=>false,          'set'=>false,
       '<name>'=>array('Guardian'), 'ship'=>true,
       '<x>'=>'100',                'shoot'=>false,
       '<y>'=>'150'


### PR DESCRIPTION
The example does not match the returned output, or the parent README:
https://github.com/docopt/docopt/blob/master/README.rst