### PR TITLE
Address PHP 8.1 deprecations

### DIFF
--- a/src/docopt.php
+++ b/src/docopt.php
@@ -876,7 +876,7 @@ namespace Docopt
         public static function fromPattern($source)
         {
             $source = preg_replace('@([\[\]\(\)\|]|\.\.\.)@', ' $1 ', $source);
-            $source = preg_split('@\s+|(\S*<.*?'.'>)@', $source, null, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
+            $source = preg_split('@\s+|(\S*<.*?'.'>)@', $source, 0, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
             
             return new static($source, 'LanguageError');
         }
@@ -1412,26 +1412,31 @@ namespace Docopt
             }
         }
 
+        #[\ReturnTypeWillChange]
         public function offsetExists($offset)
         {
             return isset($this->args[$offset]);
         }
 
+        #[\ReturnTypeWillChange]
         public function offsetGet($offset)
         {
             return $this->args[$offset];
         }
 
+        #[\ReturnTypeWillChange]
         public function offsetSet($offset, $value)
         {
             $this->args[$offset] = $value;
         }
 
+        #[\ReturnTypeWillChange]
         public function offsetUnset($offset)
         {
             unset($this->args[$offset]);
         }
 
+        #[\ReturnTypeWillChange]
         public function getIterator()
         {
             return new \ArrayIterator($this->args);

--- a/src/docopt.php
+++ b/src/docopt.php
@@ -1207,7 +1207,7 @@ namespace Docopt
         foreach (parse_section('options:', $doc) as $s) {
             # FIXME corner case "bla: options: --foo"
             list (, $s) = explode(':', $s, 2);
-            $splitTmp = array_slice(preg_split("@\n[ \t]*(-\S+?)@", "\n".$s, null, PREG_SPLIT_DELIM_CAPTURE), 1);
+            $splitTmp = array_slice(preg_split("@\n[ \t]*(-\S+?)@", "\n".$s, 0, PREG_SPLIT_DELIM_CAPTURE), 1);
             $split = array();
             for ($cnt = count($splitTmp), $i=0; $i < $cnt; $i+=2) {
                 $split[] = $splitTmp[$i] . (isset($splitTmp[$i+1]) ? $splitTmp[$i+1] : '');


### PR DESCRIPTION
Addresses two separate classes of deprecation notices in PHP 8.1:

- An argument type change to `preg_split()` (which is fixed in a backwards-compatible way by changing `null` to `0`)
- Return type changes in the `\ArrayAccess` and `\IteratorAggregate` classes (which are silenced to retain compatibility with older versions of PHP)

I may not have caught all deprecated behaviour: testing everything with PHP 8.1 will require upgrading PHPUnit significantly.