### PR TITLE
Address PHP 8.4 deprecation

### DIFF
--- a/src/docopt.php
+++ b/src/docopt.php
@@ -1455,8 +1455,12 @@ namespace Docopt
          * @param ?int $pos
          * @param Pattern $pattern
          */
-        public function __construct($pos, Pattern $pattern=null)
+        public function __construct($pos, $pattern=null)
         {
+            if ($pattern !== null && !$pattern instanceof Pattern) {
+                throw new \InvalidArgumentException();
+            }
+
             $this->pos = $pos;
             $this->pattern = $pattern;
         }


### PR DESCRIPTION
PHP 8.4 introduced a change where nullable types must be explicitly defined. When running docopt in PHP 8.4  a deprecation notice is shown:

```
PHP Deprecated:  Docopt\SingleMatch::__construct(): Implicitly marking parameter $pattern as nullable is deprecated, the explicit nullable type must be used instead
```

To maintain support of PHP 5.3 I removed the type hint entirely and added an if statement to type check. If the requirement was bumped to PHP 7.1 the type hint could remain but instead be prefixed by a `?`.